### PR TITLE
Allow a few exceptions to the standard eslint rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/index.js
+++ b/index.js
@@ -10,15 +10,23 @@ var blockCloser = /^```$/mg
 
 var standardMarkdown = module.exports = {}
 
+const disabledRules = ['no-undef', 'no-unused-vars', 'no-lone-blocks', 'no-labels']
+
 standardMarkdown.lintText = function (text, done) {
   var blocks = extractCodeBlocks(text)
   async.map(blocks, function (block, callback) {
-    return standard.lintText(block, callback)
+    const ignoredBlock = `/* eslint-disable ${disabledRules.join(', ')} */
+    ` + block
+    return standard.lintText(ignoredBlock, callback)
   }, function (err, results) {
     if (err) return done(err)
     results = results.map(function (r) {
       return r.results.map(function (res) {
-        return res.messages
+        return res.messages.map(function (message) {
+          // We added an extra line to the top of the "file" so we need to remove one here
+          message.line -= 1
+          return message
+        })
       })
     })
     results = flatten(flatten(results))

--- a/index.js
+++ b/index.js
@@ -10,12 +10,12 @@ var blockCloser = /^```$/mg
 
 var standardMarkdown = module.exports = {}
 
-const disabledRules = ['no-undef', 'no-unused-vars', 'no-lone-blocks', 'no-labels']
+var disabledRules = ['no-undef', 'no-unused-vars', 'no-lone-blocks', 'no-labels']
 
 standardMarkdown.lintText = function (text, done) {
   var blocks = extractCodeBlocks(text)
   async.map(blocks, function (block, callback) {
-    const ignoredBlock = `/* eslint-disable ${disabledRules.join(', ')} */
+    var ignoredBlock = `/* eslint-disable ${disabledRules.join(', ')} */
     ` + block
     return standard.lintText(ignoredBlock, callback)
   }, function (err, results) {

--- a/index.js
+++ b/index.js
@@ -15,8 +15,7 @@ var disabledRules = ['no-undef', 'no-unused-vars', 'no-lone-blocks', 'no-labels'
 standardMarkdown.lintText = function (text, done) {
   var blocks = extractCodeBlocks(text)
   async.map(blocks, function (block, callback) {
-    var ignoredBlock = `/* eslint-disable ${disabledRules.join(', ')} */
-    ` + block
+    var ignoredBlock = '/* eslint-disable ' + disabledRules.join(', ') + ' */\n' + block
     return standard.lintText(ignoredBlock, callback)
   }, function (err, results) {
     if (err) return done(err)

--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,15 @@ All files with `.md` or `.markdown` extension are linted, and the following dire
 - `node_modules`
 - `vendor`
 
+This module disables certain rules that were considered not appropriate for linting JS blocks in markdown. See [#2](https://github.com/zeke/standard-markdown/issues/2) for more information.
+
+Currently we disable the following rules
+
+* [`no-undef`](http://eslint.org/docs/rules/no-undef)  
+* [`no-unused-vars`](http://eslint.org/docs/rules/no-unused-vars)  
+* [`no-lone-blocks`](http://eslint.org/docs/rules/no-lone-blocks)  
+* [`no-labels`](http://eslint.org/docs/2.0.0/rules/no-labels)  
+
 ## Tests
 
 ```sh

--- a/tests/fixtures/clean.md
+++ b/tests/fixtures/clean.md
@@ -12,3 +12,16 @@ There are no linting errors in this file.
 let wibble = 2
 console.log(wibble)
 ```
+
+It should allow use of undefined variables
+
+```javascript
+win.close()
+```
+
+It should allow creation of unused variables
+
+```js
+// `BrowserWindow` is declared but not used
+const {BrowserWindow} = require('electron')
+```

--- a/tests/index.js
+++ b/tests/index.js
@@ -13,15 +13,13 @@ test('standardMarkdown', function (t) {
     // console.error(JSON.stringify(results, null, 2))
 
     t.comment('dirty fixture')
-    t.equal(results.length, 6, 'returns six linting errors')
+    t.equal(results.length, 5, 'returns six linting errors')
 
-    t.equal(results[0].message, "'foo' is defined but never used", 'finds errors')
+    t.equal(results[0].message, 'Extra semicolon.', 'finds errors in first block')
+    t.equal(results[0].line, 6, 'identifies correct line number in first block')
 
-    t.equal(results[1].message, 'Extra semicolon.', 'finds errors in first block')
-    t.equal(results[1].line, 6, 'identifies correct line number in first block')
-
-    t.equal(results[2].message, 'Extra semicolon.', 'finds errors in second block')
-    t.equal(results[2].line, 20, 'identifies correct line number in first block')
+    t.equal(results[1].message, 'Extra semicolon.', 'finds errors in second block')
+    t.equal(results[1].line, 20, 'identifies correct line number in first block')
 
     t.comment('every error')
     t.ok(results.every(function (result) {


### PR DESCRIPTION
This handles #2 by injecting an eslint disable rules comment at the top of all parsed files.

Fixes #2 

This is just a POC but I think it's a nice solution to the problem