### PR TITLE
allow orphan objects

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,12 +7,8 @@ var flatten = require('lodash.flatten')
 var async = require('async')
 var blockOpener = /^```(js|javascript)$/mg
 var blockCloser = /^```$/mg
-var openingOrphanCurly = /^\/\/ -```(js|javascript)\n\{/mg
-var closingOrphanCurly = /\}\n\/\/ -```/mg
-
-var standardMarkdown = module.exports = {}
-
 var disabledRules = ['no-undef', 'no-unused-vars', 'no-lone-blocks', 'no-labels']
+var standardMarkdown = module.exports = {}
 
 standardMarkdown.lintText = function (text, done) {
   var blocks = extractCodeBlocks(text)
@@ -92,11 +88,8 @@ then turn it into this:
 ```
 */
 function wrapOrphanObjectInParens (block) {
-  if (block.match(openingOrphanCurly) && block.match(closingOrphanCurly)) {
-    return block
-      .replace(openingOrphanCurly, '// -```js\n({')
-      .replace(closingOrphanCurly, '})\n// -```')
-  } else {
-    return block
-  }
+  return block.replace(
+    /\/\/ -```(js|javascript)\n({[\s\S]+})\n\/\/ -```/mg,
+    '// -```js\n($1)\n// -```'
+  )
 }

--- a/index.js
+++ b/index.js
@@ -7,6 +7,8 @@ var flatten = require('lodash.flatten')
 var async = require('async')
 var blockOpener = /^```(js|javascript)$/mg
 var blockCloser = /^```$/mg
+var openingOrphanCurly = /^\/\/ -```(js|javascript)\n\{/mg
+var closingOrphanCurly = /\}\n\/\/ -```/mg
 
 var standardMarkdown = module.exports = {}
 
@@ -14,7 +16,9 @@ var disabledRules = ['no-undef', 'no-unused-vars', 'no-lone-blocks', 'no-labels'
 
 standardMarkdown.lintText = function (text, done) {
   var blocks = extractCodeBlocks(text)
+
   async.map(blocks, function (block, callback) {
+    block = wrapOrphanObjectInParens(block)
     var ignoredBlock = '/* eslint-disable ' + disabledRules.join(', ') + ' */\n' + block
     return standard.lintText(ignoredBlock, callback)
   }, function (err, results) {
@@ -72,4 +76,27 @@ function extractCodeBlock (lines, targetIndex) {
     if (!insideBlock) line = '// -' + line
     return line
   }).join('\n').concat('\n') // standard requires a newline at end of file
+}
+
+/*
+If given code block is an orphan object like this:
+
+```js
+{an: 'object'}
+```
+
+then turn it into this:
+
+```js
+({an: 'object'})
+```
+*/
+function wrapOrphanObjectInParens (block) {
+  if (block.match(openingOrphanCurly) && block.match(closingOrphanCurly)) {
+    return block
+      .replace(openingOrphanCurly, '// -```js\n({')
+      .replace(closingOrphanCurly, '})\n// -```')
+  } else {
+    return block
+  }
 }

--- a/readme.md
+++ b/readme.md
@@ -37,7 +37,11 @@ Currently we disable the following rules
 * [`no-undef`](http://eslint.org/docs/rules/no-undef)  
 * [`no-unused-vars`](http://eslint.org/docs/rules/no-unused-vars)  
 * [`no-lone-blocks`](http://eslint.org/docs/rules/no-lone-blocks)  
-* [`no-labels`](http://eslint.org/docs/2.0.0/rules/no-labels)  
+* [`no-labels`](http://eslint.org/docs/2.0.0/rules/no-labels)
+
+For more examples of what is and isn't allowed, see the
+[clean](/test/fixtures/clean.md) and
+[dirty](/test/fixtures/dirty.md) test fixtures.
 
 ## Tests
 

--- a/tests/fixtures/clean.md
+++ b/tests/fixtures/clean.md
@@ -25,3 +25,18 @@ It should allow creation of unused variables
 // `BrowserWindow` is declared but not used
 const {BrowserWindow} = require('electron')
 ```
+
+It should allow orphan objects:
+
+```js
+{some: 'object'}
+```
+
+and this wrapping kind too:
+
+```js
+{
+  some: 'object',
+  with: 'different whitespace and tabbing'
+}
+```


### PR DESCRIPTION
This is a followup to #2 and #3 which allows objects to be declared like this:

```js
{some: 'object'}
```

or like this:

```js
{
  some: 'object',
  with: 'different whitespace and tabbing'
}
```

It works by covertly wrapping the objects in parentheses before linting, which makes them "valid".

cc @MarshallOfSound @kevinsawicki @jlord