### PR TITLE
support orphan arrays

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,7 +89,7 @@ then turn it into this:
 */
 function wrapOrphanObjectInParens (block) {
   return block.replace(
-    /\/\/ -```(js|javascript)\n({[\s\S]+})\n\/\/ -```/mg,
+    /\/\/ -```(js|javascript)\n([{|\[][\s\S]+[}|\]])\n\/\/ -```/mg,
     '// -```js\n($1)\n// -```'
   )
 }

--- a/tests/fixtures/clean.md
+++ b/tests/fixtures/clean.md
@@ -40,3 +40,19 @@ and this wrapping kind too:
   with: 'different whitespace and tabbing'
 }
 ```
+
+and arrays:
+
+```js
+[1,2,3]
+```
+
+and wrapped arrays:
+
+```js
+[
+  4,
+  5,
+  6,
+]
+```


### PR DESCRIPTION
#6 took care of orphan objects. This takes care of orphan arrays:

```js
['like', 'this', 'one']
```