### PR TITLE
drop node 0.10, update standard

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: node_js
 node_js:
-  - "0.10"
   - "4"
   - "6"

--- a/package.json
+++ b/package.json
@@ -24,13 +24,13 @@
     "globby": "^6.0.0",
     "lodash.flatten": "^4.2.0",
     "lodash.range": "^3.1.5",
-    "standard": "^7.1.2"
+    "standard": "^8.2.0"
   },
   "devDependencies": {
     "tap-spec": "^4.1.1",
     "tape": "^4.6.0"
   },
   "engines": {
-    "node": ">=0.10"
+    "node": ">=4"
   }
 }


### PR DESCRIPTION
`eslint` now requires node 4 or greater and `standard` followed suit.

@MarshallOfSound this should help unblock #5 