### PR TITLE
Guard clearLine and cursorTop from process.stdout

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -71,8 +71,11 @@ linter.lintFiles = function (files, standardOptions, done) {
   }
   async.map(files, function (file, callback) {
     // Inform the user of progress
-    process.stdout.clearLine && process.stdout.clearLine()
-    process.stdout.cursorTo && process.stdout.cursorTo(0)
+    if (process.stdout.clearLine && process.stdout.cursorTo) {
+      process.stdout.clearLine()
+      process.stdout.cursorTo(0)
+    }
+
     process.stdout.write('Linting file ' + (index++ + 1) + ' of ' + files.length)
 
     linter.lintText(fs.readFileSync(file, 'utf8'), standardOptions, function (err, errors, outputText) {

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -71,8 +71,8 @@ linter.lintFiles = function (files, standardOptions, done) {
   }
   async.map(files, function (file, callback) {
     // Inform the user of progress
-    process.stdout.clearLine()
-    process.stdout.cursorTo(0)
+    process.stdout.clearLine && process.stdout.clearLine()
+    process.stdout.cursorTo && process.stdout.cursorTo(0)
     process.stdout.write('Linting file ' + (index++ + 1) + ' of ' + files.length)
 
     linter.lintText(fs.readFileSync(file, 'utf8'), standardOptions, function (err, errors, outputText) {


### PR DESCRIPTION
When the shell is exec from spawn process this methods doesn't exists.