### PR TITLE
bump standard to 9

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "globby": "^6.0.0",
     "lodash.flatten": "^4.2.0",
     "lodash.range": "^3.1.5",
-    "standard": "^8.6.0"
+    "standard": "^9.0.1"
   },
   "devDependencies": {
     "tap-spec": "^4.1.1",


### PR DESCRIPTION
This should probably be a major version bump. We can continue to bump this module's major every time we bump its `standard` major.