### PR TITLE
make linting more quiet, add newline each time

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -76,8 +76,10 @@ linter.lintFiles = function (files, standardOptions, done) {
       process.stdout.cursorTo(0)
     }
 
-    process.stdout.write('Linting file ' + (index++ + 1) + ' of ' + files.length)
-
+    if (standardOptions.verbose) {
+      process.stdout.write('Linting file ' + (index++ + 1) + ' of ' + files.length + '\n')
+    }
+    
     linter.lintText(fs.readFileSync(file, 'utf8'), standardOptions, function (err, errors, outputText) {
       if (err) return callback(err)
       return callback(null, { file: file, errors: errors, input: fs.readFileSync(file, 'utf8'), output: outputText })


### PR DESCRIPTION
This is a rough proposal for improving the linting output ("rough" because I'm not sure I'm using the `standardOptions` right).

Currently when I run this on Windows I get a lot of noise:

![screen shot 2017-04-24 at 11 37 59 am](https://cloud.githubusercontent.com/assets/359239/25319536/7f0105a4-28e2-11e7-8b49-0c4ef699b6ca.png)

Aside from showing things are being processed, it's not really helpful.

What I'm suggesting here is two things:

 - newline character after each "linting" message
 - hide this behind the verbose flag

I've had a quick skim of how `cli.js` is passing things around but I'm not seeing much about how `verbose` is passed through - let me know if I'm doing this wrong.