### PR TITLE
Improve CLI output and use newest version of standard

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -9,6 +9,7 @@ const extractCodeBlocks = require('./codeBlockUtils').extractCodeBlocks
 const disabledRules = [
   'no-undef',
   'no-unused-vars',
+  'no-unused-expressions',
   'no-lone-blocks',
   'no-labels'
 ]

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -1,17 +1,19 @@
 'use strict'
 
-var fs = require('fs')
-
-var async = require('async')
-var flatten = require('lodash.flatten')
-var standard = require('standard')
-
-var extractCodeBlocks = require('./codeBlockUtils').extractCodeBlocks
-
-var disabledRules = ['no-undef', 'no-unused-vars', 'no-lone-blocks', 'no-labels']
-var eslintDisable = '/* eslint-disable ' + disabledRules.join(', ') + ' */\n'
-
-var linter = module.exports = {}
+const fs = require('fs')
+const async = require('async')
+const flatten = require('lodash.flatten')
+const standard = require('standard')
+const ora = require('ora')
+const extractCodeBlocks = require('./codeBlockUtils').extractCodeBlocks
+const disabledRules = [
+  'no-undef',
+  'no-unused-vars',
+  'no-lone-blocks',
+  'no-labels'
+]
+const eslintDisable = '/* eslint-disable ' + disabledRules.join(', ') + ' */\n'
+const linter = module.exports = {}
 
 function removeParensWrappingOrphanedObject (block) {
   return block.replace(
@@ -65,18 +67,14 @@ linter.lintText = function (text, standardOptions, done) {
 
 linter.lintFiles = function (files, standardOptions, done) {
   var index = 0
+  const spinner = (files.length > 3) ? ora().start() : null
+
   if (typeof standardOptions === 'function') {
     done = standardOptions
     standardOptions = {}
   }
   async.map(files, function (file, callback) {
-    // Inform the user of progress
-    if (process.stdout.clearLine && process.stdout.cursorTo) {
-      process.stdout.clearLine()
-      process.stdout.cursorTo(0)
-    }
-
-    process.stdout.write('Linting file ' + (index++ + 1) + ' of ' + files.length)
+    if (spinner) spinner.text('Linting file ' + (index++ + 1) + ' of ' + files.length)
 
     linter.lintText(fs.readFileSync(file, 'utf8'), standardOptions, function (err, errors, outputText) {
       if (err) return callback(err)

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "globby": "^6.0.0",
     "lodash.flatten": "^4.2.0",
     "lodash.range": "^3.1.5",
+    "ora": "^1.2.0",
     "standard": "^8.6.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lodash.flatten": "^4.2.0",
     "lodash.range": "^3.1.5",
     "ora": "^1.2.0",
-    "standard": "^8.6.0"
+    "standard": "^10.0.2"
   },
   "devDependencies": {
     "tap-spec": "^4.1.1",


### PR DESCRIPTION
Changes:

- Don't show any CLI output unless linting more than three files.
- Use [ora](https://github.com/sindresorhus/ora) for cross-platform-friendly CLI output
- Use latest standard version (10)
- Disable newly-added `no-unused-expressions` rule.

Fixes #15  

cc @MarshallOfSound @shiftkey