### PR TITLE
disable standard/no-callback-literal rule

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -9,6 +9,7 @@ const extractCodeBlocks = require('./codeBlockUtils').extractCodeBlocks
 const disabledRules = [
   'no-undef',
   'no-unused-vars',
+  'standard/no-callback-literal',
   'no-unused-expressions',
   'no-lone-blocks',
   'no-labels'

--- a/tests/fixtures/clean.md
+++ b/tests/fixtures/clean.md
@@ -56,3 +56,17 @@ and wrapped arrays:
   6
 ]
 ```
+
+Electron docs have a bunch of non-node-style callbacks that don't have `err` as the first arg:
+
+```javascript
+const {app} = require('electron')
+
+app.on('certificate-error', (event, webContents, url, error, certificate, callback) => {
+  if (url === 'https://github.com') {
+    callback(true)
+  } else {
+    callback(false)
+  }
+})
+```


### PR DESCRIPTION
Allow code to have a `callback` that doesn't have `err` as first arg:

```javascript
const {app} = require('electron')

app.on('certificate-error', (event, webContents, url, error, certificate, callback) => {
  if (url === 'https://github.com') {
    callback(true)
  } else {
    callback(false)
  }
})
```

Making this exception to accommodate Electron APIs.