### PR TITLE
Fix as cli failed

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -27,6 +27,7 @@ program
   .option('-f, --fix', 'Attempt to fix basic standard JS issues')
   .option('-v, --verbose', 'Verbose mode')
   .action(function (cwdValue, patternArgs) {
+    if (cwdValue == null) return
     // If cwd is an actual path, set it to be the cwd
     // Otherwise interpret it as a glob pattern
     if (fs.existsSync(path.resolve(cwdValue)) && fs.lstatSync(path.resolve(cwdValue)).isDirectory()) {


### PR DESCRIPTION
The following is an error.
```
path.js:39
    throw new ERR_INVALID_ARG_TYPE('path', 'string', path);
    ^

TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received type undefined
    at assertPath (path.js:39:11)
    at Object.resolve (path.js:1090:7)
    at Command.<anonymous> (/home/vagrant/work/standard-markdown/cli.js:34:28)
    at Command.listener (/home/vagrant/work/standard-markdown/node_modules/commander/index.js:315:8)
    at Command.emit (events.js:182:13)
    at Command.parseArgs (/home/vagrant/work/standard-markdown/node_modules/commander/index.js:665:12)
    at Command.parse (/home/vagrant/work/standard-markdown/node_modules/commander/index.js:474:21)
    at Object.<anonymous> (/home/vagrant/work/standard-markdown/cli.js:42:4)
    at Module._compile (internal/modules/cjs/loader.js:689:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
```

fixes: #24 