### PR TITLE
Fix that `--fix` is not executed

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -64,7 +64,7 @@ standardMarkdown[program.fix ? 'formatFiles' : 'lintFiles'](files, function (err
   if (err) throw err
 
   // No errors
-  if (results.every(function (result) { return result.errors.length === 0 })) {
+  if (!program.fix && results.every(function (result) { return result.errors.length === 0 })) {
     process.exit(0)
   }
 


### PR DESCRIPTION
fixes #23 

The `errors` in the `results` of the `formatFiles` executed with the `fix` option seemed empty.
That is, I exit on line 68.
When there is a `fix` option, I fixed not to check error.