### PR TITLE
Upgrade 'standard'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "6"
   - "8"
   - "10"
   - "12"

--- a/package.json
+++ b/package.json
@@ -20,16 +20,16 @@
   "author": "Zeke Sikelianos <zeke@sikelianos.com> (http://zeke.sikelianos.com)",
   "license": "MIT",
   "dependencies": {
-    "commander": "^2.18.0",
-    "globby": "^8.0.1",
+    "commander": "^2.20.0",
+    "globby": "^10.0.1",
     "lodash.flatten": "^4.4.0",
     "lodash.range": "^3.2.0",
-    "ora": "^3.0.0",
-    "standard": "^12.0.1"
+    "ora": "^3.4.0",
+    "standard": "^13.0.0"
   },
   "devDependencies": {
     "tap-spec": "^5.0.0",
-    "tape": "^4.9.1"
+    "tape": "^4.11.0"
   },
   "engines": {
     "node": ">=6"

--- a/tests/fixtures/clean.md
+++ b/tests/fixtures/clean.md
@@ -9,7 +9,7 @@ console.log('all good here!')
 There are no linting errors in this file.
 
 ```javascript
-let wibble = 2
+const wibble = 2
 console.log(wibble)
 ```
 


### PR DESCRIPTION
## Upgrade 'standard'
* Upgrade other packages
* Fix 'standard' error
    * 'wibble' is never reassigned. Use 'const' instead.

## Drop Node.js 6 from .travis.yml
Node.js 6 is EOL.

I get the following error in a library that does not support Node.js 6.
 
```
node_modules/eslint/lib/cli-engine/cli-engine.js:257
        ...calculateStatsPerFile(messages)
        ^^^
```