### PR TITLE
Match blocks with text after language identifier

### DIFF
--- a/lib/codeBlockUtils.js
+++ b/lib/codeBlockUtils.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const blockOpener = /^```(js|javascript)$/mg
+const blockOpener = /^```(js|javascript)(?:\s.*)?$/mg
 const blockCloser = /^```$/mg
 
 // Extract all code blocks in the file


### PR DESCRIPTION
Electron's docs make use of metadata in the info string after the language identifier for rich rendering on the website, but that causes `standard-markdown` to not match those code blocks.

Refs electron/electron#38024.